### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker HTTP Image
 [![Docker Stars](https://img.shields.io/docker/stars/deployerpt/http.svg)](https://registry.hub.docker.com/u/deployerpt/http)
-[![Docker Pulls](https://img.shields.io/docker/pulls/deployerpt/http.svg)](https://registry.hub.docker.com/u/deployerpt/http)
+[![Docker Pulls](https://img.shields.io/docker/pulls/deployerpt/http.svg)](https://registry.hub.docker.com/u/deployerpt/http) [![](https://images.microbadger.com/badges/image/deployerpt/http.svg)](https://microbadger.com/images/deployerpt/http "Get your own image badge on microbadger.com")
 
 This repository contains configuration files for building Docker image to create a simple HTTP server.
 
@@ -18,3 +18,4 @@ http:
   volumes:
     - ./code:/var/www/html
 ```
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [deployerpt/http](https://hub.docker.com/r/deployerpt/http/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/deployerpt/http).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/deployerpt/http.svg)](https://microbadger.com/images/deployerpt/http "Get your own image badge on microbadger.com")
